### PR TITLE
Set VCPKG dependency source to Hyvart's fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -39,5 +39,5 @@
 	url = https://github.com/openssl/openssl.git
 [submodule "Libs/vcpkg"]
 	path = Libs/vcpkg
-	url = https://github.com/microsoft/vcpkg.git
-	branch = master
+	url = https://github.com/hyvart/vcpkg.git
+	branch = unjammit/master

--- a/Source/FFmpegInteropLibs.props
+++ b/Source/FFmpegInteropLibs.props
@@ -7,7 +7,6 @@
     <Link>
       <AdditionalDependencies>
         avcodec.lib;
-        avdevice.lib;
         avfilter.lib;
         avformat.lib;
         avutil.lib;
@@ -16,6 +15,14 @@
         %(AdditionalDependencies)
       </AdditionalDependencies>
       <AdditionalLibraryDirectories>$(ProjectDir)..\Output\FFmpegUWP\$(PlatformTarget)\bin;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(FFmpegInteropXImportFromNuGet)' != 'false'">
+    <Link>
+      <AdditionalDependencies>
+        avdevice.lib;
+        %(AdditionalDependencies)
+      </AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(FFmpegInteropXImportFromNuGet)' == 'false'">


### PR DESCRIPTION
- Sets VCPKG submodule branch to `unjammit/master`.
- Makes `avdevice` dependency contidional.